### PR TITLE
Update docs for Anova Oven API V2

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -20,6 +20,9 @@ meta:
 
 This is the private API used by the Anova Precision Oven mobile applications.
 
+## Changelog
+- 7/25/2023: Updated to Anova Oven API V2 (oven firmware 2+)
+
 # Authentication
 
 ```shell
@@ -61,36 +64,27 @@ returnSecureToken | true | Informs the API to return a JWT token
 
 # Websocket Commands
 
-You must connect to `wss://app.oven.anovaculinary.io`.
+You must connect to `wss://devices.anovaculinary.io/?token=idToken&supportedAccessories=APO&platform=android`. Replace `idToken` with the JWT Token returned by the authentication step. Specify `ANOVA_V2` as the protocol when opening the connection.
 
-## Authentication Command
+Example JavaScript code to open the WebSocket:
 
-```json
-{
-  "command": "AUTH_TOKEN",
-  "payload": "[ID_TOKEN]",
-}
+```js
+const ws = new WebSocket(`wss://devices.anovaculinary.io/?token=${data.idToken}&supportedAccessories=APO&platform=android`, 'ANOVA_V2');
 ```
-
-> The service will respond with the following message
-
-```json
-{"response":"AUTH_TOKEN_RESPONSE"}
-```
-
-In order to authenticate, you must send a message containing the `idToken` you received in the
-earlier authorization call as the payload.
 
 ## Send Command
 
+This is the overall structure of a command message to the API:
+
 ```json
 {
-  "command": "SEND_OVEN_COMMAND",
+  "command": "<COMMAND>",
   "payload": {
-    "deviceId": "<DEVICE_ID>",
-    "command": <COMMAND>,
-    "requestId": "<REQUEST_UUID>"
-  }
+    "id": "<DEVICE_ID>",
+    "type": "<COMMAND>",
+    "payload": "<START_COOK_PAYLOAD>" # only used for start cook command, undefined otherwise
+  },
+  "requestId": "<REQUEST_UUID>"
 }
 ```
 
@@ -98,11 +92,11 @@ earlier authorization call as the payload.
 
 ```json
 {
-  "response": "OVEN_COMMAND_RESPONSE",
+  "command": "RESPONSE",
   "requestId": "<REQUEST_UUID>",
-  "deviceId": "<DEVICE_ID>",
-  "success": true,
-  "data": [{},null,null]
+  "payload": {
+    "status": "ok" 
+  }
 }
 ```
 
@@ -112,293 +106,34 @@ Parameter | Description
 --------- | -----------
 REQUEST_UUID | A UUID to differentiate this request from others.
 COMMAND | One of the Commands below
-DEVICE_ID | A unique identifer for the specific oven. In order to find the device ids that are available to you, you can wait for an <a href="#oven-state">Oven State message</a> to be received.
+DEVICE_ID | A unique identifer for the specific oven. In order to find the device ids that are available to you, you can wait for an <a href="#oven-list">Oven list message</a> or an <a href="#oven-state">Oven State message</a> to be received.
 
 # Send Command Payloads
 
 ## Start Cook
+This example payload *includes* the <a href="#send-command">Send Command</a> container.
 
 ```json
 {
-	"id": "<COMMAND_UUID>",
-	"type": "startCook",
-	"payload": {
-		"cookId": "<DEVICE_ID>",
-		"stages": [
-			{
-				"stepType": "stage",
-				"id": "<STAGE_UUID>",
-				"title": "",
-				"description": "",
-				"type": "preheat",
-				"userActionRequired": false,
-				"temperatureBulbs": {
-					"wet": {
-						"setpoint": {
-							"fahrenheit": 131,
-							"celsius": 55
-						}
-					},
-					"mode": "wet"
-				},
-				"heatingElements": {
-					"top": {
-						"on": false
-					},
-					"bottom": {
-						"on": false
-					},
-					"rear": {
-						"on": true
-					}
-				},
-				"fan": {
-					"speed": 100
-				},
-				"vent": {
-					"open": false
-				},
-				"rackPosition": 3,
-				"steamGenerators": {
-					"relativeHumidity": {
-						"setpoint": 100
-					},
-					"mode": "relative-humidity"
-				}
-			}
-		]
-	}
-}
-```
-
-This must be sent within a <a href="#send-command">Send command</a>.
-
-Parameter | Description
---------- | -----------
-COMMAND_UUID | A UUID to differentiate this command from others.
-DEVICE_ID | A unique identifer for the specific oven. In order to find the device ids that are available to you, you can wait for an <a href="#oven-state">Oven State message</a> to be received.
-STAGE_UUID | A unique identifer to differentiate this cooking stage from others.
-
-## Stop Cook
-
-```json
-{
-	"id": "<UUID>",
-	"type": "stopCook"
-}
-```
-
-This must be sent within a <a href="#send-command">Send command</a>.
-
-Parameter | Description
---------- | -----------
-UUID | A UUID to differentiate this command from others.
-
-# Websocket Messages
-
-## Oven State
-
-The oven will broadcast periodically with it's state.
-
-```json
-{
-  "response": "OVEN_STATE",
-  "ovenId": "<DEVICE_ID>",
-  "data": {
-    "version": 1,
-    "updatedTimestamp": "2023-02-07T05:37:52Z",
-    "systemInfo": {
-      "online": true,
-      "hardwareVersion": "120V Universal",
-      "powerMains": 120,
-      "powerHertz": 60,
-      "firmwareVersion": "1.4.24",
-      "uiHardwareVersion": "UI_RENASAS",
-      "uiFirmwareVersion": "1.0.22",
-      "firmwareUpdatedTimestamp": "2022-12-29T20:21:49Z",
-      "lastConnectedTimestamp": "2023-02-07T02:55:23Z",
-      "lastDisconnectedTimestamp": "2023-02-07T02:55:17Z",
-      "triacsFailed": false
-    },
-    "state": {
-      "mode": "cook",
-      "temperatureUnit": "F",
-      "processedCommandIds": [
-        "d98bcdfd-0609-4cce-8123-a79f744505b2",
-        "71102b16-27f5-4962b186-02a6d8580aac",
-        "51b5bf15-1fb4-4352-9408-24f282c79e79",
-        "d124f649-0112-4d36-8a33-90589c1f7e80",
-        "937e8575-8cb8-4372-aa39-086f77c6a3d4",
-        "f407ea2c-c31a-4b1a-8847-3b92313add97",
-        "f563a89f-44f6-4caa-bced-68a625569e7a",
-        "7799d35a-bea4-4e5f-bb8b-78921a81dd73",
-        "d17bc3ab-162a-47d4afb9-789a92e6975f",
-        "3943226a-31cf-4e94-8374-9e6a868cf255"
-      ]
-    },
-    "nodes": {
-      "temperatureBulbs": {
-        "mode": "wet",
-        "wet": {
-          "current": {
-            "celsius": 25.45,
-            "fahrenheit": 77.81
-          },
-          "setpoint": {
-            "celsius": 55,
-            "fahrenheit": 131
-          },
-          "dosed": true,
-          "doseFailed": false
-        },
-        "dry": {
-          "current": {
-            "celsius": 25.45,
-            "fahrenheit": 77.81
-          }
-        },
-        "dryTop": {
-          "current": {
-            "celsius": 25.45,
-            "fahrenheit": 77.81
-          },
-          "overheated": false
-        },
-        "dryBottom": {
-          "current": {
-            "celsius": 24.98,
-            "fahrenheit": 76.96
-          },
-          "overheated": false
-        }
-      },
-      "timer": {
-        "mode": "idle",
-        "initial": 0,
-        "current": 0
-      },
-      "temperatureProbe": {
-        "connected": false
-      },
-      "steamGenerators": {
-        "mode": "relative-humidity",
-        "relativeHumidity": {
-          "current": 100,
-          "setpoint": 100
-        },
-        "evaporator": {
-          "failed": false,
-          "overheated": false,
-          "celsius": 38.72,
-          "watts": 0
-        },
-        "boiler": {
-          "descaleRequired": false,
-          "failed": false,
-          "overheated": false,
-          "celsius": 38.72,
-          "watts": 0,
-          "dosed": false
-        }
-      },
-      "heatingElements": {
-        "top": {
-          "on": false,
-          "failed": false,
-          "watts": 0
-        },
-        "bottom": {
-          "on": false,
-          "failed": false,
-          "watts": 0
-        },
-        "rear": {
-          "on": true,
-          "failed": false,
-          "watts": 0
-        }
-      },
-      "fan": {
-        "speed": 100,
-        "failed": false
-      },
-      "vent": {
-        "open": true
-      },
-      "waterTank": {
-        "empty": false
-      },
-      "door": {
-        "closed": true
-      },
-      "lamp": {
-        "on": true,
-        "failed": false,
-        "preference": "on"
-      },
-      "userInterfaceCircuit": {
-        "communicationFailed": false
-      }
-    },
-    "cook": {
-      "cookId": "<COMMAND_UUID>",
+  "command": "CMD_APO_START",
+  "payload": {
+    "payload": {
+      "cookId": "COOK_UUID",
       "stages": [
         {
-          "title": 0,
-          "id": "<STAGE_UUID>",
-          "type": "preheat",
-          "userActionRequired": false,
-          "temperatureBulbs": {
-            "mode": "wet",
-            "wet": {
-              "setpoint": {
-                "celsius": 55,
-                "fahrenheit": 131
-              }
-            }
-          },
-          "steamGenerators": {
-            "mode": "relative-humidity",
-            "relativeHumidity": {
-              "setpoint": 100
-            }
-          },
-          "heatingElements": {
-            "top": {
-              "on": false
-            },
-            "bottom": {
-              "on": false
-            },
-            "rear": {
-              "on": true
-            }
-          },
-          "fan": {
-            "speed": 100
-          },
-          "vent": {
-            "open": false
-          }
-        },
-        {
-          "title": 0,
-          "id": "<STAGE_UUID>",
+          "stepType": "stage",
+          "id": "STAGE_UUID",
+          "title": "",
+          "description": "",
           "type": "cook",
           "userActionRequired": false,
           "temperatureBulbs": {
             "mode": "wet",
             "wet": {
               "setpoint": {
-                "celsius": 55,
-                "fahrenheit": 131
+                "celsius": 54.44,
+                "fahrenheit": 130
               }
-            }
-          },
-          "steamGenerators": {
-            "mode": "relative-humidity",
-            "relativeHumidity": {
-              "setpoint": 100
             }
           },
           "heatingElements": {
@@ -417,13 +152,302 @@ The oven will broadcast periodically with it's state.
           },
           "vent": {
             "open": false
+          },
+          "rackPosition": 3,
+          "steamGenerators": {
+            "relativeHumidity": {
+              "setpoint": 100
+            },
+            "mode": "relative-humidity"
           }
         }
-      ],
-      "activeStageId": "<STAGE_UUID>",
-      "activeStageIndex": 0,
-      "stageTransitionPendingUserAction": false,
-      "activeStageSeconecondsElapsed": 1
+      ]
+    },
+    "type": "CMD_APO_START",
+    "id": "<DEVICE_ID>"
+  },
+  "requestId": "<REQUEST_UUID>"
+}
+```
+
+
+Parameter | Description
+--------- | -----------
+COMMAND_UUID | A UUID to differentiate this command from others.
+DEVICE_ID | A unique identifer for the specific oven. In order to find the device ids that are available to you, you can wait for an <a href="#oven-state">Oven State message</a> to be received.
+COOK_ID | A unique identifier to differentiate this cook from other cooks.
+STAGE_UUID | A unique identifer to differentiate this cooking stage from others.
+
+## Stop Cook
+This example payload *includes* the <a href="#send-command">Send Command</a> container.
+
+```json
+{
+  "command": "CMD_APO_STOP",
+  "payload": {
+    "type": "CMD_APO_STOP",
+    "id": "<DEVICE_ID>"
+  },
+  "requestId": "<REQUEST_UUID>"
+}
+```
+
+Parameter | Description
+--------- | -----------
+REQUEST_UUID | A UUID to differentiate this request from others.
+DEVICE_ID | A unique identifer for the specific oven. In order to find the device ids that are available to you, you can wait for an <a href="#oven-state">Oven State message</a> to be received.
+
+# Websocket Messages
+
+## Oven List
+When you open a web socket, and periodically as the list of ovens change, the service will broadcast a list of ovens that includes the name and ID of each.
+
+```json
+{
+  "command": "EVENT_APO_WIFI_LIST",
+  "payload": [
+    {
+      "cookerId": "<DEVICE_ID>",
+      "name": "<OVEN_NAME>",
+      "pairedAt": "2023-07-25T12:46:48.538Z",
+      "type": "oven_v1"
+    }
+  ]
+}
+```
+
+## Oven State
+
+The oven will broadcast periodically with its state. This message appears to be sent every 30 seconds while a socket is open (regardless of activity).
+
+```json
+{
+  "command": "EVENT_APO_STATE",
+  "payload": {
+    "cookerId": "<DEVICE_ID>",
+    "type": "oven_v1",
+    "state": {
+      "cook": {
+        "activeStageId": "<STAGE_UUID>
+        "stages": [
+          {
+            "fan": {
+              "speed": 100
+            },
+            "heatingElements": {
+              "rear": {
+                "on": true
+              },
+              "top": {
+                "on": false
+              },
+              "bottom": {
+                "on": false
+              }
+            },
+            "temperatureBulbs": {
+              "wet": {
+                "setpoint": {
+                  "fahrenheit": 130,
+                  "celsius": 54.44
+                }
+              },
+              "mode": "wet"
+            },
+            "steamGenerators": {
+              "mode": "relative-humidity",
+              "relativeHumidity": {
+                "setpoint": 100
+              }
+            },
+            "userActionRequired": false,
+            "id": "<STAGE_UUID>",
+            "type": "preheat",
+            "vent": {
+              "open": false
+            },
+            "title": 0
+          },
+          {
+            "heatingElements": {
+              "rear": {
+                "on": true
+              },
+              "top": {
+                "on": false
+              },
+              "bottom": {
+                "on": false
+              }
+            },
+            "temperatureBulbs": {
+              "wet": {
+                "setpoint": {
+                  "celsius": 54.44,
+                  "fahrenheit": 130
+                }
+              },
+              "mode": "wet"
+            },
+            "id": "<STAGE_UUID>",
+            "type": "cook",
+            "fan": {
+              "speed": 100
+            },
+            "steamGenerators": {
+              "mode": "relative-humidity",
+              "relativeHumidity": {
+                "setpoint": 100
+              }
+            },
+            "userActionRequired": false,
+            "vent": {
+              "open": false
+            },
+            "title": 0
+          }
+        ],
+        "activeStageSecondsElapsed": 37,
+        "secondsElapsed": 37,
+        "cookId": "<COOK_UUID>",
+        "activeStageIndex": 0,
+        "stageTransitionPendingUserAction": false
+      },
+      "state": {
+        "processedCommandIds": [
+          "c3ff2a79-c4ad-4b8d-8541-cff888ee6e63",
+          "1d26f0db-3b88-49da-95e0-0a02650337f6",
+          "3f3aa1af-80c7-468a-b5bc-f655a13db621",
+          "981ff4b5-e192-4d6d-8781-ddbad8edd69f",
+          "7286d4b0-fd98-4aeb-81f4-c3aab965076d",
+          "39b1c6f7-26ee-4291-b2fa-8976729dc25a",
+          "038d47b2-db5c-4999-a53c-f63dceab74ff",
+          "2d4d289d-6c15-4477-b1a4-3f17fbdcfbe4",
+          "b0f6c33e-c8ff-4517-b8f6-36d7125cb51b",
+          "b54fe16a-f200-44cb-8ab7-09330d72f0cb"
+        ],
+        "temperatureUnit": "F",
+        "mode": "cook"
+      },
+      "nodes": {
+        "temperatureBulbs": {
+          "dryBottom": {
+            "current": {
+              "celsius": 28.75,
+              "fahrenheit": 83.75
+            },
+            "overheated": false
+          },
+          "dryTop": {
+            "current": {
+              "celsius": 28.94,
+              "fahrenheit": 84.1
+            },
+            "overheated": false
+          },
+          "wet": {
+            "current": {
+              "celsius": 28.3,
+              "fahrenheit": 82.93
+            },
+            "dosed": false,
+            "setpoint": {
+              "celsius": 54.44,
+              "fahrenheit": 129.99
+            },
+            "doseFailed": false
+          },
+          "dry": {
+            "current": {
+              "fahrenheit": 84.1,
+              "celsius": 28.94
+            }
+          },
+          "mode": "wet"
+        },
+        "steamGenerators": {
+          "mode": "relative-humidity",
+          "relativeHumidity": {
+            "current": 97,
+            "setpoint": 100
+          },
+          "boiler": {
+            "watts": 0,
+            "dosed": false,
+            "descaleRequired": false,
+            "failed": false,
+            "celsius": 38.43,
+            "overheated": false
+          },
+          "evaporator": {
+            "watts": 0,
+            "overheated": false,
+            "failed": false,
+            "celsius": 38.43
+          }
+        },
+        "lamp": {
+          "failed": false,
+          "preference": "off",
+          "on": false
+        },
+        "heatingElements": {
+          "top": {
+            "watts": 0,
+            "on": false,
+            "failed": false
+          },
+          "rear": {
+            "watts": 0,
+            "on": true,
+            "failed": false
+          },
+          "bottom": {
+            "watts": 0,
+            "failed": false,
+            "on": false
+          }
+        },
+        "userInterfaceCircuit": {
+          "communicationFailed": false
+        },
+        "timer": {
+          "mode": "idle",
+          "current": 0,
+          "initial": 0
+        },
+        "fan": {
+          "failed": false,
+          "speed": 100
+        },
+        "vent": {
+          "open": true
+        },
+        "temperatureProbe": {
+          "connected": false
+        },
+        "door": {
+          "closed": true
+        },
+        "waterTank": {
+          "empty": false
+        }
+      },
+      "systemInfo": {
+        "powerHertz": 60,
+        "lastDisconnectedTimestamp": "2023-07-25T05:57:53Z",
+        "triacsFailed": false,
+        "uiFirmwareVersion": "1.0.22",
+        "lastConnectedTimestamp": "2023-07-25T11:58:06Z",
+        "online": true,
+        "firmwareVersion": "2.0.11",
+        "uiHardwareVersion": "UI_RENASAS",
+        "powerMains": 120,
+        "hardwareVersion": "120V Universal",
+        "firmwareUpdatedTimestamp": "2023-07-10T08:56:47Z"
+      },
+      "version": 1,
+      "updatedTimestamp": "2023-07-25T12:54:07Z"
     }
   }
 }


### PR DESCRIPTION
Hi,
Thanks for the great work documenting this protocol. I've updated the documentation based on the new firmware V2 API - you can see a demo deployment of the docs at this version [on my fork](https://jon-bell.github.io/anova-oven-api/).

If it's useful, I can also share the link to a [homebridge plugin for the oven](https://github.com/jon-bell/homebridge-plugin-anova-toast), which includes a TypeScript implementation of the API client.

It would be fun to also get into Firebase and extract the list of saved recipes, so that each saved recipe from the app can become a toggle switch in the app... but running a MitM on firebase is beyond the realm of my abilities :)

Best,
Jon